### PR TITLE
drop "edit " match in chrome.storage.sync.get bc false match

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ chrome.storage.sync.get(
     { naturalLanguageHeuristics: false },
     (items) => {
         if (!editLink && items.naturalLanguageHeuristics) {
-            var KEYWORDS = ["edit ", "edit this page", "make a contribution", "view this page", "edit file"];
+            var KEYWORDS = ["edit this page", "make a contribution", "view this page", "edit file"];
             for (var i = 0; i < document.links.length; i++) {
         if (!editLink && KEYWORDS.some(kw => document.links[i].textContent.toLowerCase().includes(kw) || document.links[i].title?.toLowerCase().includes(kw) || document.links[i].ariaLabel?.toLowerCase().includes(kw))) {
             editLink = document.links[i];


### PR DESCRIPTION
When you're logged into Wikipedia, the edit button will navigate to https://en.wikipedia.org/wiki/Help:Contents because the page has the source `<a href="/wiki/Help:Contents" title="Guidance on how to use and edit Wikipedia"><span>Help</span></a>` which has the word "edit " which was one of the KEYWORDS being matched in chrome.storage.sync.get. I dropped that match as a quick patch (and I expect LOTS of other links out there may have "edit " in the title attribute).